### PR TITLE
fix: モバイル時のボタンの横幅修正

### DIFF
--- a/apps/web/components/Sponsor/Information.tsx
+++ b/apps/web/components/Sponsor/Information.tsx
@@ -37,7 +37,7 @@ function SponsorInformation({
         </Button>
         <Button
           disabled={isExpired}
-          className="w-full sm:w-auto mt-0 sm:mt-3 md:mb-10 sm:mb-3 mb-0"
+          className="w-full sm:w-auto"
           variant="neon-pink"
           asChild
         >

--- a/apps/web/components/Sponsor/Information.tsx
+++ b/apps/web/components/Sponsor/Information.tsx
@@ -27,7 +27,7 @@ function SponsorInformation({
       <div className="flex flex-wrap gap-5 md:gap-20 justify-center my-0 md:mt-3 md:mb-10">
         <Button
           disabled={isExpired}
-          className="w-full sm:w-auto"
+          className="w-full sm:w-auto py-2.5 px-10"
           variant="neon-red"
           asChild
         >
@@ -37,7 +37,7 @@ function SponsorInformation({
         </Button>
         <Button
           disabled={isExpired}
-          className="w-full sm:w-auto"
+          className="w-full sm:w-auto py-2.5 px-10"
           variant="neon-pink"
           asChild
         >

--- a/apps/web/components/Sponsor/Information.tsx
+++ b/apps/web/components/Sponsor/Information.tsx
@@ -24,7 +24,7 @@ function SponsorInformation({
       <Text className="text-white whitespace-pre-wrap">
         {INFORMATION_CONTENT}
       </Text>
-      <div className="flex flex-wrap gap-5 md:gap-20 justify-center">
+      <div className="flex flex-wrap gap-5 md:gap-20 justify-center my-0 md:mt-3 md:mb-10">
         <Button
           disabled={isExpired}
           className="w-full sm:w-auto"

--- a/apps/web/components/Sponsor/Information.tsx
+++ b/apps/web/components/Sponsor/Information.tsx
@@ -27,7 +27,7 @@ function SponsorInformation({
       <div className="flex flex-wrap gap-5 md:gap-20 justify-center">
         <Button
           disabled={isExpired}
-          className="mt-3 mb-10"
+          className="w-full sm:w-auto mt-0 sm:mt-3 md:mb-10 sm:mb-3 mb-0"
           variant="neon-red"
           asChild
         >
@@ -37,7 +37,7 @@ function SponsorInformation({
         </Button>
         <Button
           disabled={isExpired}
-          className="mt-3 mb-10"
+          className="w-full sm:w-auto mt-0 sm:mt-3 md:mb-10 sm:mb-3 mb-0"
           variant="neon-pink"
           asChild
         >

--- a/apps/web/components/Sponsor/Information.tsx
+++ b/apps/web/components/Sponsor/Information.tsx
@@ -27,7 +27,7 @@ function SponsorInformation({
       <div className="flex flex-wrap gap-5 md:gap-20 justify-center">
         <Button
           disabled={isExpired}
-          className="w-full sm:w-auto mt-0 sm:mt-3 md:mb-10 sm:mb-3 mb-0"
+          className="w-full sm:w-auto"
           variant="neon-red"
           asChild
         >


### PR DESCRIPTION
## 概要・詳細

Closes https://github.com/fec-kansai/TasksBoard/issues/36

<!-- Pull Requestの中身の概要や詳細な説明、動作確認方法などを記入してください -->

スポンサーのボタンのモバイル時の幅をFigmaを参考に修正

before

<img width="454" alt="image" src="https://github.com/user-attachments/assets/c3c903f5-d813-4f56-b684-f3364aeb927e" />

after

<img width="181" alt="image" src="https://github.com/user-attachments/assets/a43353e7-045b-401b-9541-2a338fd75497" />


## 対応背景、関連 issue など

<!-- issueがある場合はissueへのリンク、ない場合はテキストでの説明や関連するURLを添付してください -->

## スクリーンショット

<!-- UIの変更がある場合、添付するとよいです。インタラクションがある場合は動画などを添付しても構いません -->

## レビューポイント

<!-- 特に不安なところや確認してほしいポイントなどがあれば記入してください -->

## セルフレビュー

<!-- レビュワーの負担を減らすために、確認をお願いします -->

- [ ] タスクの内容を漏れなく対応する変更をした
- [ ] 動作確認をした
- [ ] CI が落ちていないことを確認した <!-- PRの作成後に走るCIを確認するので問題ありません -->
