### PR TITLE
`MainVisual`のアイコン位置を画面幅に依存しない固定基準に変更

### DIFF
--- a/apps/web/components/MainVisual.tsx
+++ b/apps/web/components/MainVisual.tsx
@@ -20,76 +20,81 @@ import styles from "assets/css/neon.module.css";
 export default function MainVisual() {
   return (
     <section className="relative w-full min-h-[calc(100vh-64px)] flex flex-col items-center justify-center">
-      {/* ロゴ中央やや上配置 */}
-      <img
-        src="/logo_w.png"
-        alt="Logo"
-        className="w-[80%] max-w-120 lg:max-w-180 h-auto drop-shadow-xl justify-center items-center"
-      />
-      <div className="absolute inset-0 w-full h-full pointer-events-none">
-        {/* 左下端：たこ焼きボックス */}
-        <div className="absolute left-[10%] md:left-[5%] bottom-[-16%] md:bottom-[-30%] w-32 md:w-50 animate-float6 -rotate-10">
-          <TakoyakiBoxIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 左上端：海遊館 */}
-        <div className="absolute left-[7%] md:left-[0%] top-[-20%] md:top-[-25%] w-30 md:w-58 animate-float1 rotate-20">
-          <KaiyukanIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 左上中央：CSS */}
-        <div className="absolute left-[50%] md:left-[25%] top-[-2%] md:top-[-40%] w-24 md:w-30 animate-float2 -rotate-10">
-          <CssIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 中央上：React */}
-        <div className="absolute left-[5%] md:left-[45%] top-[0%] md:top-[-30%] w-24 md:w-30 animate-float3 rotate-10">
-          <ReactIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 右上：Figma */}
-        <div className="absolute right-[30%] md:right-[15%] top-[-35%] md:top-[-30%] w-24 md:w-30 animate-float2 rotate-20">
-          <FigmaIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 左中央：HTML */}
-        <div className="hidden md:block absolute left-[50%] md:left-[13%] top-[-23%] md:top-[-5%] w-19 md:w-30 animate-float5 -rotate-20">
-          <HtmlIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 左下：JS */}
-        <div className="absolute left-[60%] md:left-[20%] top-[35%] md:top-[40%] w-19 md:w-30 animate-float4 rotate-20">
-          <JsIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 下：PHP */}
-        <div className="absolute left-[5%] md:left-[34%] top-[67%] md:top-[55%] w-19 md:w-38 animate-float5 -rotate-20">
-          <PhpIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 右下：Vue */}
-        <div className="absolute right-[64%] md:right-[25%] top-[37%] md:top-[50%] w-19 md:w-38 animate-float4 -rotate-10">
-          <VueIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 右：Laravel */}
-        <div className="absolute right-[10%] md:right-[10%] top-[60%] md:top-[15%] w-19 md:w-38 animate-float6 rotate-20">
-          <LaravelIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 中央上：タコ */}
-        <div className="hidden md:block absolute left-[50%] top-[-23%] md:top-[15%] w-19 md:w-38 animate-float5 -rotate-20">
-          <OctopusIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 右上端：通天閣 */}
-        <div className="absolute right-[8%] md:right-[3%] bottom-[-30%] md:bottom-[-45%] w-19 md:w-38 animate-float4 -rotate-20">
-          <TsuutenkakuIcon className={styles["neon-icon"]} />
-        </div>
-        {/* 右下端：太陽の塔 */}
-        <div className="absolute right-[0%] md:right-[12%] top-[5%] md:top-[5%] w-26 md:w-48 animate-float5 rotate-20">
-          <TowerOfSunIcon className={styles["neon-icon"]} />
-        </div>
-        {/* ミニたこ焼き1 */}
-        <div className="absolute right-[40%] md:right-[62%] top-[46%] md:top-[44%] w-14 md:w-30 -rotate-10">
-          <TakoyakiIcon className={styles["neon-icon"]} />
-        </div>
-        {/* ミニたこ焼き2 */}
-        <div className="absolute left-[5%] md:left-[4%] top-[20%] md:top-[6%] w-14 md:w-30 -rotate-180">
-          <TakoyakiIcon className={styles["neon-icon"]} />
-        </div>
-        {/* ミニたこ焼き3 */}
-        <div className="absolute right-[30%] md:right-[30%] top-[-20%] md:top-[-36%] w-14 md:w-30 rotate-40">
-          <TakoyakiIcon className={styles["neon-icon"]} />
+      {/* アイコンの基準となる固定サイズの親要素 */}
+      <div className="relative w-[720px] h-[440px]">
+        {/* ロゴ中央配置（レスポンシブサイズ） */}
+        <img
+          src="/logo_w.png"
+          alt="Logo"
+          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[80vw] max-w-180 h-auto drop-shadow-xl z-10"
+        />
+
+        {/* アイコン群 - 固定サイズの親要素を基準にした相対位置 */}
+        <div className="absolute inset-0 pointer-events-none">
+          {/* 左下端：たこ焼きボックス */}
+          <div className="absolute left-[27%] md:left-[-40%] bottom-[-90%] md:bottom-[-75%] w-32 md:w-40 animate-float6 -rotate-10">
+            <TakoyakiBoxIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 左上端：海遊館 */}
+          <div className="absolute left-[30%] md:left-[-40%] top-[-90%] md:top-[-70%] w-30 md:w-48 animate-float1 rotate-20">
+            <KaiyukanIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 左上中央：CSS */}
+          <div className="absolute left-[55%] md:left-[-5%] top-[-45%] md:top-[-75%] w-24 md:w-30 animate-float2 -rotate-10">
+            <CssIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 中央上：React */}
+          <div className="absolute left-[25%] md:left-[40%] top-[-50%] md:top-[-60%] w-24 md:w-30 animate-float3 rotate-10">
+            <ReactIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 右上：Figma */}
+          <div className="absolute right-[35%] md:right-[-14%] top-[-115%] md:top-[-85%] w-24 md:w-30 animate-float2 rotate-20">
+            <FigmaIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 左中央：HTML */}
+          <div className="hidden md:block absolute left-[-30%] top-[-25%] w-19 md:w-30 animate-float5 -rotate-20">
+            <HtmlIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 左下：JS */}
+          <div className="absolute left-[58%] md:left-[-8%] bottom-[-50%] md:bottom-[-63%] w-19 md:w-30 animate-float4 rotate-20">
+            <JsIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 下：PHP */}
+          <div className="absolute left-[25%] md:left-[20%] bottom-[-75%] md:bottom-[-40%] w-19 md:w-38 animate-float5 -rotate-20">
+            <PhpIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 右下：Vue */}
+          <div className="absolute right-[58%] md:right-[0%] top-[38%] md:top-[50%] w-19 md:w-38 animate-float4 -rotate-10">
+            <VueIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 右：Laravel */}
+          <div className="absolute right-[26%] md:right-[-25%] top-[65%] md:top-[-10%] w-19 md:w-38 animate-float6 rotate-20">
+            <LaravelIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 中央上：タコ */}
+          <div className="absolute left-[45%] md:left-[55%] top-[-8%] md:top-[10%] w-19 md:w-38 animate-float5 -rotate-20">
+            <OctopusIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 右上端：通天閣 */}
+          <div className="absolute right-[25%] md:right-[-45%] bottom-[-80%] md:bottom-[-90%] w-19 md:w-38 animate-float4 -rotate-20">
+            <TsuutenkakuIcon className={styles["neon-icon"]} />
+          </div>
+          {/* 右下端：太陽の塔 */}
+          <div className="absolute right-[27%] md:right-[-40%] top-[-30%] md:top-[-35%] w-26 md:w-48 animate-float5 rotate-20">
+            <TowerOfSunIcon className={styles["neon-icon"]} />
+          </div>
+          {/* ミニたこ焼き1 */}
+          <div className="absolute left-[50%] md:left-[9%] top-[55%] md:top-[40%] w-14 md:w-20 -rotate-10">
+            <TakoyakiIcon className={styles["neon-icon"]} />
+          </div>
+          {/* ミニたこ焼き2 */}
+          <div className="absolute left-[27%] md:left-[-45%] top-[0%] md:top-[-40%] w-14 md:w-20 -rotate-180">
+            <TakoyakiIcon className={styles["neon-icon"]} />
+          </div>
+          {/* ミニたこ焼き3 */}
+          <div className="absolute right-[43%] md:right-[17%] top-[-70%] md:top-[-75%] w-14 md:w-20 rotate-40">
+            <TakoyakiIcon className={styles["neon-icon"]} />
+          </div>
         </div>
       </div>
       <div className="absolute bottom-0 left-1/2 -translate-x-1/2 flex flex-col items-center z-10 mb-6">

--- a/apps/web/components/MainVisual.tsx
+++ b/apps/web/components/MainVisual.tsx
@@ -1,11 +1,19 @@
 "use client";
 import {
+  CssIcon,
+  FigmaIcon,
+  HtmlIcon,
+  JsIcon,
   KaiyukanIcon,
+  LaravelIcon,
   OctopusIcon,
+  PhpIcon,
+  ReactIcon,
   TakoyakiBoxIcon,
   TakoyakiIcon,
   TowerOfSunIcon,
   TsuutenkakuIcon,
+  VueIcon,
 } from "@workspace/ui";
 import styles from "assets/css/neon.module.css";
 
@@ -20,19 +28,51 @@ export default function MainVisual() {
       />
       <div className="absolute inset-0 w-full h-full pointer-events-none">
         {/* 左下端：たこ焼きボックス */}
-        <div className="absolute left-[5%] md:left-[10%] bottom-[-25%] md:bottom-[-25%] w-32 md:w-50 animate-float6 -rotate-10">
+        <div className="absolute left-[10%] md:left-[5%] bottom-[-16%] md:bottom-[-30%] w-32 md:w-50 animate-float6 -rotate-10">
           <TakoyakiBoxIcon className={styles["neon-icon"]} />
         </div>
         {/* 左上端：海遊館 */}
-        <div className="absolute left-[7%] md:left-[9%] top-[-20%] md:top-[-25%] w-30 md:w-58 animate-float1 rotate-20">
+        <div className="absolute left-[7%] md:left-[0%] top-[-20%] md:top-[-25%] w-30 md:w-58 animate-float1 rotate-20">
           <KaiyukanIcon className={styles["neon-icon"]} />
         </div>
+        {/* 左上中央：CSS */}
+        <div className="absolute left-[50%] md:left-[25%] top-[-2%] md:top-[-40%] w-24 md:w-30 animate-float2 -rotate-10">
+          <CssIcon className={styles["neon-icon"]} />
+        </div>
+        {/* 中央上：React */}
+        <div className="absolute left-[5%] md:left-[45%] top-[0%] md:top-[-30%] w-24 md:w-30 animate-float3 rotate-10">
+          <ReactIcon className={styles["neon-icon"]} />
+        </div>
+        {/* 右上：Figma */}
+        <div className="absolute right-[30%] md:right-[15%] top-[-35%] md:top-[-30%] w-24 md:w-30 animate-float2 rotate-20">
+          <FigmaIcon className={styles["neon-icon"]} />
+        </div>
+        {/* 左中央：HTML */}
+        <div className="hidden md:block absolute left-[50%] md:left-[13%] top-[-23%] md:top-[-5%] w-19 md:w-30 animate-float5 -rotate-20">
+          <HtmlIcon className={styles["neon-icon"]} />
+        </div>
+        {/* 左下：JS */}
+        <div className="absolute left-[60%] md:left-[20%] top-[35%] md:top-[40%] w-19 md:w-30 animate-float4 rotate-20">
+          <JsIcon className={styles["neon-icon"]} />
+        </div>
+        {/* 下：PHP */}
+        <div className="absolute left-[5%] md:left-[34%] top-[67%] md:top-[55%] w-19 md:w-38 animate-float5 -rotate-20">
+          <PhpIcon className={styles["neon-icon"]} />
+        </div>
+        {/* 右下：Vue */}
+        <div className="absolute right-[64%] md:right-[25%] top-[37%] md:top-[50%] w-19 md:w-38 animate-float4 -rotate-10">
+          <VueIcon className={styles["neon-icon"]} />
+        </div>
+        {/* 右：Laravel */}
+        <div className="absolute right-[10%] md:right-[10%] top-[60%] md:top-[15%] w-19 md:w-38 animate-float6 rotate-20">
+          <LaravelIcon className={styles["neon-icon"]} />
+        </div>
         {/* 中央上：タコ */}
-        <div className="hidden md:block absolute left-[40%] top-[-23%] md:top-[-44%] w-19 md:w-38 animate-float5 -rotate-20">
+        <div className="hidden md:block absolute left-[50%] top-[-23%] md:top-[15%] w-19 md:w-38 animate-float5 -rotate-20">
           <OctopusIcon className={styles["neon-icon"]} />
         </div>
         {/* 右上端：通天閣 */}
-        <div className="absolute right-[8%] bottom-[-30%] md:bottom-[-25%] w-19 md:w-38 animate-float4 -rotate-20">
+        <div className="absolute right-[8%] md:right-[3%] bottom-[-30%] md:bottom-[-45%] w-19 md:w-38 animate-float4 -rotate-20">
           <TsuutenkakuIcon className={styles["neon-icon"]} />
         </div>
         {/* 右下端：太陽の塔 */}
@@ -40,7 +80,7 @@ export default function MainVisual() {
           <TowerOfSunIcon className={styles["neon-icon"]} />
         </div>
         {/* ミニたこ焼き1 */}
-        <div className="absolute right-[20%] md:right-[10%] top-[25%] md:top-[14%] w-14 md:w-30 -rotate-10">
+        <div className="absolute right-[40%] md:right-[62%] top-[46%] md:top-[44%] w-14 md:w-30 -rotate-10">
           <TakoyakiIcon className={styles["neon-icon"]} />
         </div>
         {/* ミニたこ焼き2 */}
@@ -48,7 +88,7 @@ export default function MainVisual() {
           <TakoyakiIcon className={styles["neon-icon"]} />
         </div>
         {/* ミニたこ焼き3 */}
-        <div className="absolute right-[30%] md:right-[35%] top-[-20%] md:top-[-36%] w-14 md:w-30 rotate-40">
+        <div className="absolute right-[30%] md:right-[30%] top-[-20%] md:top-[-36%] w-14 md:w-30 rotate-40">
           <TakoyakiIcon className={styles["neon-icon"]} />
         </div>
       </div>


### PR DESCRIPTION
## 概要・詳細

Closes [#40](https://github.com/fec-kansai/TasksBoard/issues/40)

<!-- Pull Requestの中身の概要や詳細な説明、動作確認方法などを記入してください -->
画面幅からtop/leftを指定するのではなく、画面中央の要素からtop/leftを指定して、画面サイズを変えてもロゴの位置がずれないように修正

## 対応背景、関連 issue など

<!-- issueがある場合はissueへのリンク、ない場合はテキストでの説明や関連するURLを添付してください -->

## スクリーンショット

<!-- UIの変更がある場合、添付するとよいです。インタラクションがある場合は動画などを添付しても構いません -->

## レビューポイント

<!-- 特に不安なところや確認してほしいポイントなどがあれば記入してください -->

## セルフレビュー

<!-- レビュワーの負担を減らすために、確認をお願いします -->

- [ ] タスクの内容を漏れなく対応する変更をした
- [ ] 動作確認をした
- [ ] CI が落ちていないことを確認した <!-- PRの作成後に走るCIを確認するので問題ありません -->
