### PR TITLE
fix: fix og image path

### DIFF
--- a/.github/workflows/pipeline-prd.yml
+++ b/.github/workflows/pipeline-prd.yml
@@ -45,3 +45,5 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy ./_deploy --project-name=fec-kansai-2025 --commit-dirty=true --branch=main
+        env:
+          NEXT_PUBLIC_BASE_URL: https://frontend-conf.osaka.jp


### PR DESCRIPTION
## 概要・詳細

`og:image`がlocalhostになっており、OGP画像が表示されていません。
動作確認環境が無い為、動作確認ができておらず恐縮ですが、問題を把握していただけるだけでも幸いです。

## 対応背景、関連 issue など

リンクをとあるチャットで共有したところ、OGP画像がリンク切れになっていることを発見しました。
X でも報告させていただきましたが、気づいていただけていないようでしたのでPRさせていただきました。

該当の環境変数を使用している箇所
https://github.com/search?q=repo%3Afec-kansai%2Ffec-kansai-2025%20NEXT_PUBLIC_BASE_URL&type=code
https://github.com/search?q=repo%3Afec-kansai%2Ffec-kansai-2025%20BASE_URL&type=code

## スクリーンショット

LPのソースを表示したところ
<img width="499" height="23" alt="image" src="https://github.com/user-attachments/assets/a06becb5-b2b1-4ceb-a19f-03204202d92e" />

## レビューポイント

大変恐縮ですが、環境がなく、動作確認ができておりません。
動作の確認をお願いします。

## セルフレビュー

- [x] タスクの内容を漏れなく対応する変更をした
- [ ] 動作確認をした
- [ ] CI が落ちていないことを確認した <!-- PRの作成後に走るCIを確認するので問題ありません -->
