### PR TITLE
fix: タイムテーブルを 見る に表記変更、他修正

### DIFF
--- a/apps/web/components/TimeTableInformation.tsx
+++ b/apps/web/components/TimeTableInformation.tsx
@@ -1,4 +1,11 @@
-import { Button, Heading } from "@workspace/ui";
+import { Button, Heading, Text } from "@workspace/ui";
+
+const TIME_TABLE_CONTENT =
+  `フロントエンドカンファレンス関西 2025 のタイムテーブルは、最新トレンドから実務に役立つ内容まで、多彩なセッションが揃っています。
+オープニングは、Sakito さんによる基調講演からスタート。どんな話が飛び出すのか、今から楽しみです。
+
+セッションの合間には交流やリフレッシュの時間も用意されており、他の参加者とのつながりも深められます。
+タイムテーブルをチェックして、気になるセッションを見つけましょう！` as const;
 
 const TIME_TABLE_LINK = "https://fortee.jp/fec-kansai-2025/timetable";
 
@@ -6,6 +13,9 @@ export const TimeTableInformation = () => {
   return (
     <section id="timetable" className="flex flex-col gap-10 items-center">
       <Heading>タイムテーブル</Heading>
+      <Text className="text-white whitespace-pre-wrap">
+        {TIME_TABLE_CONTENT}
+      </Text>
       <div className="flex flex-wrap gap-5 md:gap-20 justify-center my-0 md:mt-5 md:mb-10">
         <Button
           className="w-full sm:w-auto py-2.5 px-10"
@@ -13,7 +23,7 @@ export const TimeTableInformation = () => {
           asChild
         >
           <a href={TIME_TABLE_LINK} target="_blank" rel="noopener noreferrer">
-            タイムテーブル
+            タイムテーブルを見る
           </a>
         </Button>
       </div>


### PR DESCRIPTION
## 概要・詳細

<!-- Pull Requestの中身の概要や詳細な説明、動作確認方法などを記入してください -->

ユーザーに行動を促す力を強くするため（動詞を使う）

変更前: タイムテーブル
変更後: **タイムテーブルを見る**

その他、ユーザーに対して、ワクワクさせる説明文も追加しました

```
フロントエンドカンファレンス関西 2025 のタイムテーブルは、最新トレンドから実務に役立つ内容まで、多彩なセッションが揃っています。
オープニングは、Sakito さんによる基調講演からスタート。どんな話が飛び出すのか、今から楽しみです。

セッションの合間には交流やリフレッシュの時間も用意されており、他の参加者とのつながりも深められます。
タイムテーブルをチェックして、気になるセッションを見つけましょう！
```

## 対応背景、関連 issue など

<!-- issueがある場合はissueへのリンク、ない場合はテキストでの説明や関連するURLを添付してください -->

## スクリーンショット

<!-- UIの変更がある場合、添付するとよいです。インタラクションがある場合は動画などを添付しても構いません -->

## レビューポイント

<!-- 特に不安なところや確認してほしいポイントなどがあれば記入してください -->

## セルフレビュー

<!-- レビュワーの負担を減らすために、確認をお願いします -->

- [ ] タスクの内容を漏れなく対応する変更をした
- [ ] 動作確認をした
- [ ] CI が落ちていないことを確認した <!-- PRの作成後に走るCIを確認するので問題ありません -->
